### PR TITLE
Add testing to list of items for publishing

### DIFF
--- a/development/publishing_repositories.md
+++ b/development/publishing_repositories.md
@@ -25,6 +25,7 @@ If a project clearly meets the guidelines described above (or if the team determ
 - The README has any applicable badges added for the project to indicate build status, maintenance status, etc.
 - The project has our [issue and pull request templates](https://github.com/drud/general/tree/master/.github) if we will be accepting issues and pull requests from outside contributors.
 - The project has a LICENSE committed in the root of repo. The Apache 2.0 License should be used for all DRUD projects. If a different license is more appropriate or required for a project, create a ticket in drud/general to discuss the circumstances for that project.
+- If possible, Circleci tests should be configured, enabled, useful, and passing. Circle config would normally involve configuration of building on forked repos as well.
 - The project should have no work-in-progress feature branches, and the immediate commit history should provide appropriate, meaningful commit messages.
 - Ideally, the project provides at least one tagged release.
 - Ideally, the project provides some level of test coverage.


### PR DESCRIPTION
## The Problem:

Add Circle config to list of items for publishing a repo. 

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

