### PR TITLE
Adds 'blocker' label description to community docs.

### DIFF
--- a/development/issue_workflow.md
+++ b/development/issue_workflow.md
@@ -19,6 +19,8 @@ Labels are designated with a diamond shape in the flow diagram.
 
 - **actionable**: Requests that are ready to be handed to development for scheduling.
 
+- **blocker**: This request is preventing another issue within the an sprint from being worked on. Ideally, this should be prioritized above other requests.
+
 - **hibernate**: Requests that we are not interested in pursuing at this time, but would like to leave open to revisit at a later date.
 
 - **incubate**: Requests that are within 1-2 sprints and need additional clarity.

--- a/development/issue_workflow.md
+++ b/development/issue_workflow.md
@@ -19,7 +19,7 @@ Labels are designated with a diamond shape in the flow diagram.
 
 - **actionable**: Requests that are ready to be handed to development for scheduling.
 
-- **blocker**: This request is preventing another issue within the an sprint from being worked on. Ideally, this should be prioritized above other requests.
+- **blocker**: This request is preventing another issue within an active project board from being worked on. Ideally, this should be prioritized above other requests.
 
 - **hibernate**: Requests that we are not interested in pursuing at this time, but would like to leave open to revisit at a later date.
 


### PR DESCRIPTION
## The Problem:

* OP https://github.com/drud/general/issues/137. We need to add a definition of the new "blocker" label to our community docs.

## The Fix:

* The label was already applied using drud/ghlabel. This PR simply adds the text to our drud/community documentation.