### PR TITLE
Semantic Versioning Documentation, for drud/ddev #352

### DIFF
--- a/development/product_release.md
+++ b/development/product_release.md
@@ -13,6 +13,7 @@ Issue Summary:
 "Remaining actions:
 
 * [ ] Review release (product owner)
+* [ ] Confirm [Semantic Versioning compatibility](https://github.com/drud/ddev/issues/352)(release manager)
 * [ ] Approve release (product owner and release manager)
 * [ ] Create binaries (any DRUD maintainer)
 * [ ] Draft release notes (release manager)

--- a/governance.md
+++ b/governance.md
@@ -58,6 +58,10 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 ### Attribution
 This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4, available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4/).
 
+### Versioning
+
+By default, all public facing code repositories will commit to [Semantic Version 2.0.0](https://semver.org/) unless otherwise specified in their respective README.md file. Additional context on this decision can be read in [Ensure ddev is properly utilizing Semantic Versioning](https://github.com/drud/ddev/issues/352)
+
 ## Repository Guidelines
 
 All code projects use the [MIT License](https://opensource.org/licenses/MIT). Documentation repositories should use the [Creative Commons License version 4.0](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
## The Problem:

We committed to support this and we just need some additional documentation outside the issue queues to both 1) make this more obvious to an end-users and 2) make this as part of our release processes.

## The Fix:

See verbiage in PR.

## Related Issue Link(s):

OP [drud/ddev/issue/352](https://github.com/drud/ddev/issues/352)