### PR TITLE
remove duplicate "needs tests"

### DIFF
--- a/development/development_workflow.md
+++ b/development/development_workflow.md
@@ -25,8 +25,6 @@ Flow control points are designated with a diamond shape in the flow diagram.
 
 - **Needs Tests?**: You should write tests if you are responsible for supplying documentation to satisfy the request.
 
-- **Needs Tests?**: You should write tests if you are responsible for supplying documentation to satisfy the request.
-
 - **Ready for Review?**: Is the issue ready for a pull request or is there still more work that is needed?
 
 ### Labels


### PR DESCRIPTION
## The Problem:

"needs tests" explanation is repeated twice:

## The Fix:

remove that duplicate line

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

copy edit only

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

no, not code.

